### PR TITLE
msg/srv syntax highlight, comment toggle, snippet

### DIFF
--- a/rosmsg.sublime-snippet
+++ b/rosmsg.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[Header header]]></content>
+    <tabTrigger>Hea</tabTrigger>
+    <scope>source.rosmsg</scope>
+    <description>Header Snippet</description>
+</snippet>

--- a/rosmsg.sublime-syntax
+++ b/rosmsg.sublime-syntax
@@ -1,0 +1,64 @@
+%YAML 1.2
+---
+name: ROS Message
+# srv files are 2 messages with a --- separator
+file_extensions: [msg,srv]
+scope: source.rosmsg
+
+variables:
+  primitives: \b(bool|int8|uint8|int16|uint16|int32|uint32|int64|uint64|float32|float64|string|time|duration)\b
+  id: '(?:[\p{L}_$][\p{L}\p{N}_$]*)'
+
+contexts:
+  main:
+    - include: comment
+    # for string constants, text after inline '#' isn't parsed as comment
+    - include: string-constant
+    - include: code
+  
+  comment:
+    - match: '#'
+      scope: punctuation.definition.comment.rosmsg
+      push:
+        - meta_scope: comment.line.number-sign.rosmsg
+        - match: \n
+          pop: true
+  
+  string-constant:
+    # String constants, matches 'string' in 'string fieldname = STRING'
+    - match: 'string(?=\s+{{id}}\s+=)'
+      scope: storage.type.rosmsg
+      push:
+        - meta_scope: meta.string.line.rosmsg
+        # Matches the equals
+        - include: equals
+        # Matches all chars after = in string constant declaration
+        - match: (?<==).*
+          scope: string.unquoted.rosmsg
+        - match: \n
+          pop: true
+
+  code:
+    - include: equals
+    - include: types
+    - include: constants-and-special-vars 
+  
+  equals:
+    - match: (=)
+      scope: keyword.operator.assignment.java
+
+  types:
+    # match ROS primitive types
+    - match: '{{primitives}}'
+      scope: storage.type.rosmsg
+    # match package/Message or 'Header'
+    - match: '({{id}}/{{id}})|Header'
+      scope: support.class.rosmsg
+
+  constants-and-special-vars:
+    # match numeric values
+    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
+      scope: constant.numeric.rosmsg
+    # Match constant names (Sublime colors constant name the same as the value)
+    # - match: '{{id}}'
+      # scope: constant.other.rosmsg

--- a/rosmsg.tmPreferences
+++ b/rosmsg.tmPreferences
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+
+<dict>
+  <key>name</key>
+  <string>Comments</string>
+  <key>scope</key>
+  <string>source.rosmsg</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string># </string>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Syntax highlighting for ROS msg & srv files in Sublime Text 3 (build >= 3084). When users type 'Hea' tab completion completes to 'Header header'. Also does comment toggling for msg & srv files (CTRL+SHIFT+/)

**Syntax highligthing**
![syntax_highlighting](https://cloud.githubusercontent.com/assets/5847785/23569519/a7652f12-002d-11e7-8aa0-9331b9da2479.png)

**Header snippet**
![header_snippet](https://cloud.githubusercontent.com/assets/5847785/23569518/a76289ec-002d-11e7-9355-8fc2bbb7faab.png)
